### PR TITLE
add Elys Network testnet bech32 prefix `elys`

### DIFF
--- a/slip-0173.md
+++ b/slip-0173.md
@@ -83,6 +83,7 @@ These are the registered human-readable parts for usage in Bech32 encoding of wi
 | Dyson Protocol           | `dys`         |          |             |
 | Echelon                  | `echelon`     |          |             |
 | e-Money                  | `emoney`      |          |             |
+| Elys Network             |               | `elys`   |             |
 | Ethos                    | `ethos`       |          |             |
 | Evmos                    | `evmos`       |          |             |
 | Fetch                    | `fetch`       |          |             |


### PR DESCRIPTION
Elys Network is currently in testnet, registering the `elys` prefix here prior adding to the cosmos chain registry. Our github is  https://github.com/elys-network

email: team@elys.network
twitter: @elys_network